### PR TITLE
Adding support for creating Flows

### DIFF
--- a/sipstack-core/src/main/java/io/sipstack/transaction/Transaction.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/Transaction.java
@@ -1,5 +1,7 @@
 package io.sipstack.transaction;
 
+import io.sipstack.transport.Flow;
+
 /**
  * @author jonas@jonasborjesson.com
  */
@@ -8,4 +10,17 @@ public interface Transaction {
     TransactionId id();
 
     TransactionState state();
+
+    /**
+     * The {@link Flow} associated with this {@link Transaction}.
+     *
+     * Every {@link Transaction} will always have a flow associated with
+     * it but a flow can die. If a flow will die, the transport layer will
+     * try and re-establish that flow but may of course not succeed.
+     *
+     * TODO: show how to correctly handle a flow recovery scenario etc.
+     *
+     * @return
+     */
+    Flow flow();
 }

--- a/sipstack-core/src/main/java/io/sipstack/transaction/Transactions.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/Transactions.java
@@ -33,5 +33,7 @@ public interface Transactions {
      * @param msg
      * @return
      */
-    Transaction send(SipMessage msg);
+    // Transaction send(SipMessage msg);
+
+    Flow.Builder createFlow(String host) throws IllegalArgumentException;
 }

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/DefaultTransactionStore.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/DefaultTransactionStore.java
@@ -3,6 +3,7 @@ package io.sipstack.transaction.impl;
 import io.pkts.packet.sip.SipMessage;
 import io.sipstack.config.TransactionLayerConfiguration;
 import io.sipstack.transaction.TransactionId;
+import io.sipstack.transport.Flow;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +29,7 @@ public class DefaultTransactionStore implements TransactionStore {
 
 
     @Override
-    public TransactionHolder ensureTransaction(final boolean isUpstream, final SipMessage sipMsg) {
+    public TransactionHolder ensureTransaction(final boolean isUpstream, final Flow flow, final SipMessage sipMsg) {
         final TransactionId id = TransactionId.create(sipMsg);
         return transactions[Math.abs(id.hashCode() % stores)].computeIfAbsent(id, obj -> {
 
@@ -39,9 +40,9 @@ public class DefaultTransactionStore implements TransactionStore {
 
             if (sipMsg.isInvite()) {
                 if (isUpstream) {
-                    return factory.createInviteServerTransaction(id, sipMsg.toRequest(), config);
+                    return factory.createInviteServerTransaction(id, flow, sipMsg.toRequest(), config);
                 } else {
-                    return factory.createInviteClientTransaction(id, sipMsg.toRequest(), config);
+                    return factory.createInviteClientTransaction(id, flow, sipMsg.toRequest(), config);
                 }
             }
 
@@ -53,7 +54,7 @@ public class DefaultTransactionStore implements TransactionStore {
             }
 
             if (isUpstream) {
-                return factory.createNonInviteServerTransaction(id, sipMsg.toRequest(), config);
+                return factory.createNonInviteServerTransaction(id, flow, sipMsg.toRequest(), config);
             } else {
                 throw new RuntimeException("Haven't done the NonInviteClientTransaction just yet");
             }

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/InviteServerTransactionActor.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/InviteServerTransactionActor.java
@@ -116,7 +116,6 @@ public class InviteServerTransactionActor extends ActorSupport<Event, Transactio
      */
     private Cancellable timerL;
 
-
     /**
      * @param id
      * @param initialState

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/NonInviteServerTransactionActor.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/NonInviteServerTransactionActor.java
@@ -88,8 +88,8 @@ public class NonInviteServerTransactionActor extends ActorSupport<Event, Transac
     private Cancellable timerJ;
 
     protected NonInviteServerTransactionActor(final TransactionId id,
-                                           final SipRequest request,
-                                           final TransactionLayerConfiguration config) {
+                                              final SipRequest request,
+                                              final TransactionLayerConfiguration config) {
         super(id.toString(), TransactionState.INIT, TransactionState.TERMINATED, TransactionState.values());
 
         this.id = id;

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionFactory.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionFactory.java
@@ -3,6 +3,7 @@ package io.sipstack.transaction.impl;
 import io.pkts.packet.sip.SipRequest;
 import io.sipstack.config.TransactionLayerConfiguration;
 import io.sipstack.transaction.TransactionId;
+import io.sipstack.transport.Flow;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -10,14 +11,17 @@ import io.sipstack.transaction.TransactionId;
 public interface TransactionFactory {
 
     TransactionHolder createInviteServerTransaction(TransactionId id,
+                                                    Flow flow,
                                                     SipRequest request,
                                                     TransactionLayerConfiguration config);
 
     TransactionHolder createInviteClientTransaction(TransactionId id,
+                                                    Flow flow,
                                                     SipRequest request,
                                                     TransactionLayerConfiguration config);
 
     TransactionHolder createNonInviteServerTransaction(TransactionId id,
+                                                       Flow flow,
                                                        SipRequest request,
                                                        TransactionLayerConfiguration config);
 }

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionHolder.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionHolder.java
@@ -3,8 +3,6 @@ package io.sipstack.transaction.impl;
 import io.sipstack.transaction.Transaction;
 import io.sipstack.transport.Flow;
 
-import java.util.Optional;
-
 /**
  * @author jonas@jonasborjesson.com
  */
@@ -12,5 +10,5 @@ public interface TransactionHolder extends Transaction {
 
     TransactionActor actor();
 
-    Optional<Flow> flow();
+    Flow flow();
 }

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionStore.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionStore.java
@@ -2,6 +2,7 @@ package io.sipstack.transaction.impl;
 
 import io.pkts.packet.sip.SipMessage;
 import io.sipstack.transaction.TransactionId;
+import io.sipstack.transport.Flow;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -17,10 +18,11 @@ public interface TransactionStore {
      *                   lower level parts of the stack traveling "up") and as such, if it is a request we should
      *                   create a server transaction. If false, then it is traveling the opposite direction and as such
      *                   we need to create a client transaction.
+     * @param flow every transaction
      * @param msg
      * @return
      */
-    TransactionHolder ensureTransaction(boolean isUpstream, SipMessage msg);
+    TransactionHolder ensureTransaction(boolean isUpstream, Flow flow, SipMessage msg);
 
     TransactionHolder get(TransactionId id);
 

--- a/sipstack-core/src/main/java/io/sipstack/transactionuser/DefaultTransactionUser.java
+++ b/sipstack-core/src/main/java/io/sipstack/transactionuser/DefaultTransactionUser.java
@@ -25,7 +25,7 @@ public class DefaultTransactionUser implements TransactionUser {
     @Override
     public void onRequest(Transaction transaction, SipRequest request) {
         if (!request.isAck()) {
-            transactions.send(request.createResponse(200));
+            transactions.send(transaction.flow(), request.createResponse(200));
         }
     }
 

--- a/sipstack-core/src/main/java/io/sipstack/transport/Flow.java
+++ b/sipstack-core/src/main/java/io/sipstack/transport/Flow.java
@@ -1,6 +1,9 @@
 package io.sipstack.transport;
 
 import io.sipstack.netty.codec.sip.ConnectionId;
+import io.sipstack.netty.codec.sip.Transport;
+
+import java.util.function.Consumer;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -25,5 +28,26 @@ public interface Flow {
 
     default String failedReason() {
         return "bajs";
+    }
+
+    interface Builder {
+
+        Builder withPort(int port);
+
+        Builder withTransport(Transport transport);
+
+        Builder onSuccess(Consumer<Flow> consumer);
+
+        Builder onFailure(Consumer<Flow> consumer);
+
+        Builder onCancelled(Consumer<Flow> consumer);
+
+        /**
+         *
+         * @return
+         * @throws IllegalArgumentException in case any of the supplied arguments are wrong
+         * or some of the mandatory arguments are missing.
+         */
+        FlowFuture connect() throws IllegalArgumentException;
     }
 }

--- a/sipstack-core/src/main/java/io/sipstack/transport/FlowFuture.java
+++ b/sipstack-core/src/main/java/io/sipstack/transport/FlowFuture.java
@@ -3,5 +3,8 @@ package io.sipstack.transport;
 /**
  * @author jonas@jonasborjesson.com
  */
-public interface FlowActor {
+public interface FlowFuture {
+
+    boolean cancel();
+
 }

--- a/sipstack-core/src/main/java/io/sipstack/transport/Transports.java
+++ b/sipstack-core/src/main/java/io/sipstack/transport/Transports.java
@@ -30,4 +30,12 @@ public interface Transports {
      */
     void write(Flow flow, SipMessage msg);
 
+    /**
+     *
+     * @param host
+     * @return
+     * @throws IllegalArgumentException
+     */
+    Flow.Builder createFlow(String host) throws IllegalArgumentException;
+
 }

--- a/sipstack-core/src/test/java/io/sipstack/transaction/impl/InviteClientTransactionActorTest.java
+++ b/sipstack-core/src/test/java/io/sipstack/transaction/impl/InviteClientTransactionActorTest.java
@@ -70,6 +70,7 @@ public class InviteClientTransactionActorTest extends TransactionTestBase {
     public void testProceedingToAccepted() throws Exception {
         for (int i = 100; i < 200; ++i) {
             for (int j = 200; j < 300; ++j) {
+                System.out.println("Testing provisional " + i + " then final " + j);
                 final Holder holder = initiateTransition(i);
                 final SipResponse response = holder.message().createResponse(j);
                 final Flow flow = Mockito.mock(Flow.class);
@@ -153,7 +154,11 @@ public class InviteClientTransactionActorTest extends TransactionTestBase {
 
         // ask our "application", which is just a Transaction User and that is using the
         // transaction layer to send requests/responses, to send an INVITE.
-        final Transaction t1 = myApplication.sendRequest(invite);
+        myApplication.sendRequest(invite);
+
+        // TODO: need to fetch the transaction here.
+        final Transaction t1 = null;
+
 
         // the INVITE should have been sent through the transaction layer down to the
         // transport layer, for which we have a mock implementation so check that we

--- a/sipstack-core/src/test/java/io/sipstack/transaction/impl/MockTransportLayer.java
+++ b/sipstack-core/src/test/java/io/sipstack/transaction/impl/MockTransportLayer.java
@@ -2,12 +2,16 @@ package io.sipstack.transaction.impl;
 
 import io.pkts.packet.sip.SipMessage;
 import io.pkts.packet.sip.SipRequest;
+import io.pkts.packet.sip.impl.PreConditions;
+import io.sipstack.netty.codec.sip.Transport;
 import io.sipstack.transaction.Transaction;
 import io.sipstack.transport.Flow;
+import io.sipstack.transport.FlowFuture;
 import io.sipstack.transport.Transports;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -57,5 +61,58 @@ public class MockTransportLayer implements Transports {
     public void write(final Flow flow, final SipMessage msg) {
         storage.store(msg);
         latch.get().countDown();
+    }
+
+    @Override
+    public Flow.Builder createFlow(final String host) throws IllegalArgumentException {
+        PreConditions.ensureNotEmpty(host, "Host cannot be empty");
+        return null;
+    }
+
+    private static final class MockFlowBuilder implements Flow.Builder {
+
+        private final String host;
+
+        private MockFlowBuilder(final String host) {
+            this.host = host;
+        }
+
+        @Override
+        public Flow.Builder withPort(int port) {
+            return null;
+        }
+
+        @Override
+        public Flow.Builder withTransport(Transport transport) {
+            return null;
+        }
+
+        @Override
+        public Flow.Builder onSuccess(Consumer<Flow> consumer) {
+            return null;
+        }
+
+        @Override
+        public Flow.Builder onFailure(Consumer<Flow> consumer) {
+            return null;
+        }
+
+        @Override
+        public Flow.Builder onCancelled(Consumer<Flow> consumer) {
+            return null;
+        }
+
+        @Override
+        public FlowFuture connect() throws IllegalArgumentException {
+            return null;
+        }
+    }
+
+    private static final class MockFlowFuture implements FlowFuture {
+
+        @Override
+        public boolean cancel() {
+            return false;
+        }
     }
 }

--- a/sipstack-netty-codec-sip/src/main/java/io/sipstack/netty/codec/sip/UdpConnection.java
+++ b/sipstack-netty-codec-sip/src/main/java/io/sipstack/netty/codec/sip/UdpConnection.java
@@ -12,11 +12,6 @@ import java.net.InetSocketAddress;
  */
 public final class UdpConnection extends AbstractConnection {
 
-    // public UdpConnection(final ChannelHandlerContext ctx, final InetSocketAddress remoteAddress)
-    // {
-    // super(ctx, remoteAddress);
-    // }
-
     public UdpConnection(final Channel channel, final InetSocketAddress remoteAddress) {
         super(Transport.udp, channel, remoteAddress);
     }

--- a/sipstack-network-layer/src/main/java/io/sipstack/net/ListeningPoint.java
+++ b/sipstack-network-layer/src/main/java/io/sipstack/net/ListeningPoint.java
@@ -4,8 +4,11 @@
 package io.sipstack.net;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.pkts.packet.sip.address.SipURI;
+import io.sipstack.netty.codec.sip.Transport;
 
+import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.pkts.packet.sip.impl.PreConditions.assertNotNull;
@@ -21,21 +24,28 @@ public final class ListeningPoint {
 
     private final SipURI listenAddress;
     private final SipURI vipAddress;
+    private final Transport transport;
 
     private final AtomicReference<Channel> channel = new AtomicReference<>();
 
     /**
      * 
      */
-    private ListeningPoint(final SipURI listenAddress, final SipURI vipAddress) {
+    private ListeningPoint(final Transport transport, final SipURI listenAddress, final SipURI vipAddress) {
         this.listenAddress = listenAddress;
         this.vipAddress = vipAddress;
+        this.transport = transport;
     }
 
-    public static ListeningPoint create(final SipURI listen, final SipURI vipAddress) {
+    public static ListeningPoint create(final Transport transport, final SipURI listen, final SipURI vipAddress) {
+        assertNotNull(transport);
         assertNotNull(listen);
         assertNotNull(vipAddress);
-        return new ListeningPoint(listen, vipAddress);
+        return new ListeningPoint(transport, listen, vipAddress);
+    }
+
+    public Transport getTransport() {
+        return this.transport;
     }
 
     public SipURI getListenAddress() {
@@ -53,6 +63,11 @@ public final class ListeningPoint {
 
     public Channel getChannel() {
         return this.channel.get();
+    }
+
+    public ChannelFuture connect(final SocketAddress address) {
+        final Channel channel = this.channel.get();
+        return channel.connect(address, channel.voidPromise());
     }
 
     @Override

--- a/sipstack-network-layer/src/main/java/io/sipstack/net/NettyNetworkLayer.java
+++ b/sipstack-network-layer/src/main/java/io/sipstack/net/NettyNetworkLayer.java
@@ -15,15 +15,19 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.Future;
 import io.sipstack.config.NetworkInterfaceConfiguration;
+import io.sipstack.netty.codec.sip.Connection;
 import io.sipstack.netty.codec.sip.SipMessageDatagramDecoder;
 import io.sipstack.netty.codec.sip.SipMessageEncoder;
 import io.sipstack.netty.codec.sip.SipMessageStreamDecoder;
+import io.sipstack.netty.codec.sip.Transport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,17 +62,28 @@ public class NettyNetworkLayer implements NetworkLayer {
 
     private final List<NettyNetworkInterface> interfaces;
 
+    private final NettyNetworkInterface defaultInterface;
+
     /**
      * 
      */
     private NettyNetworkLayer(final CountDownLatch latch, final List<NettyNetworkInterface> ifs) {
         this.latch = latch;
         this.interfaces = ifs;
+
+        // TODO: make this configurable. For now, it is simply the
+        // first one...
+        this.defaultInterface = ifs.get(0);
     }
 
     @Override
     public void start() {
         this.interfaces.forEach(NettyNetworkInterface::up);
+    }
+
+    @Override
+    public Future<Connection> connect(final InetSocketAddress address, final Transport transport) {
+        return this.defaultInterface.connect(address, transport);
     }
 
     @Override

--- a/sipstack-network-layer/src/main/java/io/sipstack/net/NetworkInterface.java
+++ b/sipstack-network-layer/src/main/java/io/sipstack/net/NetworkInterface.java
@@ -1,9 +1,11 @@
 package io.sipstack.net;
 
 import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.Future;
+import io.sipstack.netty.codec.sip.Connection;
 import io.sipstack.netty.codec.sip.Transport;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 
 /**
  * @author jonas@jonasborjesson.com
@@ -38,5 +40,5 @@ public interface NetworkInterface {
      * @throws IllegalTransportException in case the {@link NetworkInterface} isn't configured with
      *         the specified {@link Transport}
      */
-    ChannelFuture connect(final SocketAddress remoteAddress, final Transport transport);
+    Future<Connection> connect(final InetSocketAddress remoteAddress, final Transport transport);
 }

--- a/sipstack-network-layer/src/main/java/io/sipstack/net/NetworkLayer.java
+++ b/sipstack-network-layer/src/main/java/io/sipstack/net/NetworkLayer.java
@@ -1,5 +1,11 @@
 package io.sipstack.net;
 
+import io.netty.util.concurrent.Future;
+import io.sipstack.netty.codec.sip.Connection;
+import io.sipstack.netty.codec.sip.Transport;
+
+import java.net.InetSocketAddress;
+
 /**
  * @author jonas@jonasborjesson.com
  */
@@ -10,6 +16,16 @@ public interface NetworkLayer {
      * the configured network interfaces.
      */
     void start();
+
+    /**
+     * Attempt to connect to the specified address using the specified transport protocol.
+     * The default {@link NetworkInterface} will be used.
+     *
+     * @param address
+     * @param transport
+     * @return
+     */
+    Future<Connection> connect(InetSocketAddress address, Transport transport);
 
     /**
      * Hang on this network layer until all interfaces have been shutdown and as such


### PR DESCRIPTION
- The transport layer exposes a method for creating a new flow via a Flow.Builder which returns a FlowFuture.
- All transactions will always be associated with a flow
- When sending a request via the transport layer, you must always specify the flow.
