### PR TITLE
ACK Support for server transaction

### DIFF
--- a/sipstack-core/src/main/java/io/sipstack/actor/ActorSupport.java
+++ b/sipstack-core/src/main/java/io/sipstack/actor/ActorSupport.java
@@ -41,7 +41,7 @@ public abstract class ActorSupport<T, S extends Enum<S>> implements Actor {
 
     private ActorContext currentContext;
 
-    protected ActorSupport(final String id, final S initialState, final S terminalState, final S[] values) {
+    protected ActorSupport(final String id, final S initialState, final S terminalState, final S ... values) {
         this.id = id;
         currentState = initialState;
         this.terminalState = terminalState;

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/AckTransactionActor.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/AckTransactionActor.java
@@ -1,0 +1,59 @@
+package io.sipstack.transaction.impl;
+
+import io.sipstack.actor.ActorSupport;
+import io.sipstack.event.Event;
+import io.sipstack.transaction.TransactionId;
+import io.sipstack.transaction.TransactionState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The ACK to a 2xx response doesn't really have a transaction per se. Various RFC states that it goes
+ * in its own transaction but that transaction doesn't really have any state associated with it etc etc.
+ * However, to make the {@link io.sipstack.transaction.TransactionUser} interface consistent, we will
+ * create a mini FSM representing an ACK transaction which dies right away.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public class AckTransactionActor extends ActorSupport<Event, TransactionState> implements TransactionActor {
+
+    private static final Logger logger = LoggerFactory.getLogger(AckTransactionActor.class);
+
+    private final TransactionId id;
+    private final boolean isServerTransaction;
+
+    protected AckTransactionActor(final TransactionId id, final boolean isServerTransaction) {
+        super(id.toString(), TransactionState.INIT, TransactionState.TERMINATED, TransactionState.values());
+        this.id = id;
+        this.isServerTransaction = isServerTransaction;
+
+        when(TransactionState.INIT, this::onInit);
+    }
+
+    /**
+     * The init state. Just make sure that the first event we receive is the same INVITE as created
+     * the transaction (yes, we compare references in this case, that's what we want) and then
+     * transition over to the proceeding state.
+     */
+    private void onInit(final Event event) {
+        if (event.isSipRequestEvent()) {
+            if (isServerTransaction) {
+                ctx().forwardUpstream(event);
+            } else {
+                ctx().forwardDownstream(event);
+            }
+        }
+        become(TransactionState.TERMINATED);
+    };
+
+
+    @Override
+    protected Logger logger() {
+        return logger;
+    }
+
+    @Override
+    public TransactionId id() {
+        return id;
+    }
+}

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/DefaultTransactionStore.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/DefaultTransactionStore.java
@@ -50,7 +50,7 @@ public class DefaultTransactionStore implements TransactionStore {
             // therefore goes in its own transaction but then ACKs doesn't actually have a real
             // transaction so therefore, screw it...
             if (sipMsg.isAck()) {
-                return null;
+                return factory.createAckTransaction(id, isUpstream, flow, sipMsg.toRequest(), config);
             }
 
             if (isUpstream) {

--- a/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionFactory.java
+++ b/sipstack-core/src/main/java/io/sipstack/transaction/impl/TransactionFactory.java
@@ -24,4 +24,9 @@ public interface TransactionFactory {
                                                        Flow flow,
                                                        SipRequest request,
                                                        TransactionLayerConfiguration config);
+    TransactionHolder createAckTransaction(TransactionId id,
+                                           boolean isServer,
+                                           Flow flow,
+                                           SipRequest request,
+                                           TransactionLayerConfiguration config);
 }

--- a/sipstack-core/src/test/java/io/sipstack/transaction/impl/InviteServerTransactionActorTest.java
+++ b/sipstack-core/src/test/java/io/sipstack/transaction/impl/InviteServerTransactionActorTest.java
@@ -24,6 +24,30 @@ public class InviteServerTransactionActorTest extends TransactionTestBase {
         super.setUp();
     }
 
+    /**
+     * An ACK to a 200 goes in its own transaction, even though it actually doesn't really
+     * have a transaction.
+     *
+     * @throws Exception
+     */
+    // @Test(timeout = 500)
+    @Test
+    public void testAckTo200() throws Exception {
+        final Transaction transaction = transitionToAccepted(200);
+
+        // note, we create the ACK based on the defaultInviteRequest
+        // but if that isn't true then we are screwed since it won't
+        // be the same dialog. But then again, we are testing the
+        // transaction level so it wouldn't matchi this ACK to
+        // anything anyway...
+        final Flow flow = Mockito.mock(Flow.class);
+        transactionLayer.onMessage(flow, defaultAckRequest);
+
+        final Transaction ackTransaction = myApplication.assertAndConsumeRequest("ack");
+        assertThat(ackTransaction.flow(), is(flow));
+
+        myApplication.ensureTransactionTerminated(ackTransaction.id());
+    }
 
     /**
      * Ensure that we can transition to the completed state correctly

--- a/sipstack-core/src/test/java/io/sipstack/transaction/impl/MockTransactionUser.java
+++ b/sipstack-core/src/test/java/io/sipstack/transaction/impl/MockTransactionUser.java
@@ -87,6 +87,10 @@ public class MockTransactionUser implements TransactionUser {
     public void onRequest(final Transaction transaction, final SipRequest request) {
         storage.store(transaction, request);
 
+        if (request.isAck()) {
+            return;
+        }
+
         final Optional<SipHeader> header = request.getHeader("X-Transaction-Test-Response");
         int responseCode = 200;
         if (header.isPresent()) {


### PR DESCRIPTION
- Added a AckTransaction which is a simple actor that pretty much has no state. This is only for ACK to 2xx which is the only ack that goes in its own transaction.
- Unit tests
